### PR TITLE
add fluentd label by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Go controller for the Seldon Core CRD
 Clone into GOPATH.
 
 Kubebuilder is required to build the project.
-
+Run `export GO111MODULE=off`
 Run with `make`
 
 ### Historical Notes

--- a/pkg/controller/seldondeployment/seldondeployment_controller.go
+++ b/pkg/controller/seldondeployment/seldondeployment_controller.go
@@ -278,7 +278,7 @@ func createEngineDeployment(mlDep *machinelearningv1alpha2.SeldonDeployment, p *
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        depName,
 			Namespace:   getNamespace(mlDep),
-			Labels:      map[string]string{machinelearningv1alpha2.Label_svc_orch: "true", machinelearningv1alpha2.Label_seldon_app: seldonId, machinelearningv1alpha2.Label_seldon_id: seldonId, "app": depName, "version": "v1"},
+			Labels:      map[string]string{machinelearningv1alpha2.Label_svc_orch: "true", machinelearningv1alpha2.Label_seldon_app: seldonId, machinelearningv1alpha2.Label_seldon_id: seldonId, "app": depName, "version": "v1", "fluentd": "true"},
 			Annotations: mlDep.Spec.Annotations,
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -511,7 +511,7 @@ func createComponents(mlDep *machinelearningv1alpha2.SeldonDeployment) (*compone
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      depName,
 					Namespace: namespace,
-					Labels:    map[string]string{machinelearningv1alpha2.Label_seldon_id: seldonId, "app": depName},
+					Labels:    map[string]string{machinelearningv1alpha2.Label_seldon_id: seldonId, "app": depName, "fluentd": "true"},
 				},
 				Spec: appsv1.DeploymentSpec{
 					Selector: &metav1.LabelSelector{
@@ -519,7 +519,7 @@ func createComponents(mlDep *machinelearningv1alpha2.SeldonDeployment) (*compone
 					},
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Labels:      map[string]string{machinelearningv1alpha2.Label_seldon_id: seldonId, "app": depName},
+							Labels:      map[string]string{machinelearningv1alpha2.Label_seldon_id: seldonId, "app": depName, "fluentd": "true"},
 							Annotations: mlDep.Spec.Annotations,
 						},
 						Spec: cSpec.Spec,

--- a/pkg/controller/seldondeployment/seldondeployment_controller.go
+++ b/pkg/controller/seldondeployment/seldondeployment_controller.go
@@ -568,11 +568,12 @@ func createComponents(mlDep *machinelearningv1alpha2.SeldonDeployment) (*compone
 				deploy.Spec.Selector.MatchLabels[machinelearningv1alpha2.Label_seldon_app] = seldonId
 				deploy.Spec.Template.ObjectMeta.Labels[machinelearningv1alpha2.Label_seldon_app] = seldonId
 
-				// add predictor labels
-				for k, v := range p.Labels {
-					deploy.ObjectMeta.Labels[k] = v
-					deploy.Spec.Template.ObjectMeta.Labels[k] = v
-				}
+			}
+
+			// add predictor labels
+			for k, v := range p.Labels {
+				deploy.ObjectMeta.Labels[k] = v
+				deploy.Spec.Template.ObjectMeta.Labels[k] = v
 			}
 
 			// create services for each container


### PR DESCRIPTION
To be used in https://github.com/SeldonIO/seldon-core/pull/616 , ensuring only pods labelled 'fluentd':'true' are logged.

This would ensure that the label is applied by default, even if the user does not set it. Can then be overridden to false. Am [changing the helm charts to provide that option to set to true/false](https://github.com/SeldonIO/seldon-core/pull/616/commits/33e96d3ce6367706f5a40e29c04e83b1919d8e9a). Would not allow any way to remove the label.

Not entirely clear to me whether we want to do the defaulting in the operator or at the example/chart level. For prometheus we are defaulting in the operator.