### PR TITLE
Create main service and routing when deployments ready

### DIFF
--- a/pkg/controller/seldondeployment/ambassador.go
+++ b/pkg/controller/seldondeployment/ambassador.go
@@ -31,7 +31,7 @@ type AmbassadorConfig struct {
 	TimeoutMs    int                    `yaml:"timeout_ms"`
 	Headers      map[string]string      `yaml:"headers,omitempty"`
 	RegexHeaders map[string]string      `yaml:"regex_headers,omitempty"`
-	Weight       int32                    `yaml:"weight,omitempty"`
+	Weight       int32                  `yaml:"weight,omitempty"`
 	Shadow       *bool                  `yaml:"shadow,omitempty"`
 	RetryPolicy  *AmbassadorRetryPolicy `yaml:"retry_policy,omitempty"`
 }
@@ -68,7 +68,7 @@ func getAmbassadorRestConfig(mlDep *machinelearningv1alpha2.SeldonDeployment,
 		Prefix:     "/seldon/" + serviceNameExternal + "/",
 		Service:    serviceName + "." + namespace + ":" + strconv.Itoa(engine_http_port),
 		TimeoutMs:  timeout,
-		Weight: weight,
+		Weight:     weight,
 	}
 
 	if addNamespace {

--- a/pkg/controller/seldondeployment/seldondeployment_controller.go
+++ b/pkg/controller/seldondeployment/seldondeployment_controller.go
@@ -836,7 +836,7 @@ func createServices(r *ReconcileSeldonDeployment, components *components, instan
 	ready := true
 	for _, svc := range components.services {
 		if !all {
-			if _,ok := svc.Annotations[AMBASSADOR_ANNOTATION]; ok {
+			if _, ok := svc.Annotations[AMBASSADOR_ANNOTATION]; ok {
 				log.Info("Skipping Ambassador Svc")
 				continue
 			}


### PR DESCRIPTION

 To ensure rolling updates don't allow access to services before they are ready.