### PR TITLE
distinct liveness endpoint

### DIFF
--- a/pkg/controller/seldondeployment/seldondeployment_controller.go
+++ b/pkg/controller/seldondeployment/seldondeployment_controller.go
@@ -266,7 +266,7 @@ func createEngineContainer(mlDep *machinelearningv1alpha2.SeldonDeployment, p *m
 			FailureThreshold:    1,
 			SuccessThreshold:    1,
 			TimeoutSeconds:      2},
-		LivenessProbe: &corev1.Probe{Handler: corev1.Handler{HTTPGet: &corev1.HTTPGetAction{Port: intstr.FromString("admin"), Path: "/ready", Scheme: corev1.URISchemeHTTP}},
+		LivenessProbe: &corev1.Probe{Handler: corev1.Handler{HTTPGet: &corev1.HTTPGetAction{Port: intstr.FromString("admin"), Path: "/live", Scheme: corev1.URISchemeHTTP}},
 			InitialDelaySeconds: 20,
 			PeriodSeconds:       5,
 			FailureThreshold:    7,


### PR DESCRIPTION
Otherwise the liveness probe does a full readiness check, which can timeout and lead to a restart