### PR TITLE
support using envFrom to inject credential in initContainers

### DIFF
--- a/config/crds/machinelearning_v1alpha2_seldondeployment.yaml
+++ b/config/crds/machinelearning_v1alpha2_seldondeployment.yaml
@@ -88,6 +88,8 @@ spec:
                           type:
                             type: string
                         type: object
+                      envSecretRefName:
+                        type: string
                       implementation:
                         type: string
                       methods:

--- a/pkg/apis/machinelearning/v1alpha2/seldondeployment_types.go
+++ b/pkg/apis/machinelearning/v1alpha2/seldondeployment_types.go
@@ -315,6 +315,7 @@ type PredictiveUnit struct {
 	Parameters         []Parameter                   `json:"parameters,omitempty" protobuf:"bytes,7,opt,name=parameters"`
 	ModelURI           string                        `json:"modelUri,omitempty" protobuf:"bytes,8,opt,name=modelUri"`
 	ServiceAccountName string                        `json:"serviceAccountName,omitempty" protobuf:"bytes,9,opt,name=serviceAccountName"`
+	EnvSecretRefName   string                        `json:"envSecretRefName,omitempty" protobuf:"bytes,10,opt,name=envSecretRefName"`
 }
 
 type DeploymentStatus struct {

--- a/pkg/controller/seldondeployment/model_initializer_injector.go
+++ b/pkg/controller/seldondeployment/model_initializer_injector.go
@@ -59,7 +59,7 @@ func credentialsBuilder(Client client.Client) (credentialsBuilder *credentials.C
 }
 
 // InjectModelInitializer injects an init container to provision model data
-func InjectModelInitializer(deployment *appsv1.Deployment, containerName string, srcURI string, serviceAccountName string, Client client.Client) (deploy *appsv1.Deployment, err error) {
+func InjectModelInitializer(deployment *appsv1.Deployment, containerName string, srcURI string, serviceAccountName string, envSecretRefName string, Client client.Client) (deploy *appsv1.Deployment, err error) {
 
 	if srcURI == "" {
 		return deployment, nil
@@ -185,6 +185,18 @@ func InjectModelInitializer(deployment *appsv1.Deployment, containerName string,
 		&podSpec.Volumes,
 	); err != nil {
 		return nil, err
+	}
+
+	// Inject credentials using secretRef
+	if envSecretRefName != "" {
+		initContainer.EnvFrom = append(initContainer.EnvFrom,
+			corev1.EnvFromSource{
+				SecretRef: &corev1.SecretEnvSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: envSecretRefName,
+					},
+				},
+			})
 	}
 
 	// Add init container to the spec

--- a/pkg/controller/seldondeployment/seldondeployment_explainers.go
+++ b/pkg/controller/seldondeployment/seldondeployment_explainers.go
@@ -129,7 +129,7 @@ func createExplainer(r *ReconcileSeldonDeployment, mlDep *machinelearningv1alpha
 		}}
 		deploy := createDeploymentWithoutEngine(depName, seldonId, &seldonPodSpec, p, mlDep)
 
-		deploy, err := InjectModelInitializer(deploy, explainerContainer.Name, p.Explainer.ModelUri, p.Explainer.ServiceAccountName, r.Client)
+		deploy, err := InjectModelInitializer(deploy, explainerContainer.Name, p.Explainer.ModelUri, p.Explainer.ServiceAccountName, "", r.Client)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/seldondeployment/seldondeployment_prepackaged_servers.go
+++ b/pkg/controller/seldondeployment/seldondeployment_prepackaged_servers.go
@@ -129,7 +129,7 @@ func addTFServerContainer(r *ReconcileSeldonDeployment, pu *machinelearningv1alp
 			deploy.Spec.Template.Spec.Containers = append(deploy.Spec.Template.Spec.Containers, *tfServingContainer)
 		}
 
-		_, err := InjectModelInitializer(deploy, tfServingContainer.Name, pu.ModelURI, pu.ServiceAccountName, r)
+		_, err := InjectModelInitializer(deploy, tfServingContainer.Name, pu.ModelURI, pu.ServiceAccountName, pu.EnvSecretRefName, r)
 		if err != nil {
 			return err
 		}
@@ -200,7 +200,7 @@ func addModelDefaultServers(r *ReconcileSeldonDeployment, pu *machinelearningv1a
 			}
 		}
 
-		_, err := InjectModelInitializer(deploy, c.Name, pu.ModelURI, pu.ServiceAccountName, r.Client)
+		_, err := InjectModelInitializer(deploy, c.Name, pu.ModelURI, pu.ServiceAccountName, pu.EnvSecretRefName, r.Client)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION

As discussed in https://github.com/SeldonIO/seldon-core/issues/749, using initContainer to download model requires setting up a ServiceAccount and the associated Secret in a specific way so the secret can be placed into the environment variable of the container.  In addition, annotation is used to inject the S3 endpoint.  This makes things harder than it used to be, and in my opinion, harder than it needs to be.

This PR implements a quick way of retaining the old mechanism via EnvFrom.