### PR TITLE
TFServing container: override Docker entrypoint.

### DIFF
--- a/pkg/controller/seldondeployment/seldondeployment_prepackaged_servers.go
+++ b/pkg/controller/seldondeployment/seldondeployment_prepackaged_servers.go
@@ -74,8 +74,10 @@ func addTFServerContainer(r *ReconcileSeldonDeployment, pu *machinelearningv1alp
 		tfServingContainer = &v1.Container{
 			Name:  constants.TFServingContainerName,
 			Image: "tensorflow/serving:latest",
-			Args: []string{
+			Command: []string{
 				"/usr/bin/tensorflow_model_server",
+			}
+			Args: []string{
 				"--port=2000",
 				"--rest_api_port=2001",
 				"--model_name=" + pu.Name,

--- a/pkg/controller/seldondeployment/seldondeployment_prepackaged_servers.go
+++ b/pkg/controller/seldondeployment/seldondeployment_prepackaged_servers.go
@@ -85,10 +85,12 @@ func addTFServerContainer(r *ReconcileSeldonDeployment, pu *machinelearningv1alp
 				{
 					ContainerPort: 2000,
 					Protocol:      v1.ProtocolTCP,
+					Name:          "grpc",
 				},
 				{
 					ContainerPort: 2001,
 					Protocol:      v1.ProtocolTCP,
+					Name:          "rest",
 				},
 			},
 		}


### PR DESCRIPTION
Default Docker entrypoint is a bash script for easy tfserving start. We don't need it since we re-define all arguments and we don't want it since it will swallow all OOM & co informations. https://github.com/tensorflow/serving/blame/master/tensorflow_serving/tools/docker/Dockerfile\#L59.

Also minor changes (that I can remove and/or dedicate to their PRs): 
    TFServer: add container ports names.
    prepackaged servers: directly return if implementation is not what we want.
